### PR TITLE
Use more gm options : -auto-orient, -strip

### DIFF
--- a/prosopopee/prosopopee.py
+++ b/prosopopee/prosopopee.py
@@ -100,7 +100,7 @@ class Image(object):
             shutil.copyfile(source, target)
             print source, "->", target
         else:
-            command = "gm convert -auto-orient %s %s" % (source, target)
+            command = "gm convert %s -auto-orient -strip %s" % (source, target)
             print command
             os.system(command)
 
@@ -116,8 +116,8 @@ class Image(object):
         if CACHE.thumbnail_needs_to_be_generated(source, target, self):
             gm_options = ""
             if self.autoorient:
-              gm_options = "-auto-orient "
-            command = "gm convert %s %s -resize %s -quality %s %s" % (gm_options, source, gm_geometry, self.quality, target)
+              gm_options = "-auto-orient"
+            command = "gm convert %s -strip %s -resize %s -quality %s %s" % (source, gm_options, gm_geometry, self.quality, target)
             print command
             os.system(command)
             CACHE.cache_thumbnail(source, target, self)

--- a/prosopopee/prosopopee.py
+++ b/prosopopee/prosopopee.py
@@ -68,14 +68,26 @@ class Image(object):
     def __init__(self, options):
         # assuming string
         if not isinstance(options, dict):
-            name = options
             options = {"name": options}
 
-        self.name = name
-        self.quality = options.get("quality", DEFAULT_GM_QUALITY)
-        self.autoorient = options.get("auto-orient", DEFAULT_GM_AUTOORIENT)
+        if not options.has_key("quality"):
+            options["quality"] = DEFAULT_GM_QUALITY
+        if not options.has_key("autoorient"):
+            options["autoorient"] = DEFAULT_GM_AUTOORIENT
+
         self.options = options.copy()  # used for caching, if it's modified -> regenerate
-        del self.options["name"]
+
+    @property
+    def name(self):
+      return self.options["name"]
+
+    @property
+    def quality(self):
+      return self.options["quality"]
+
+    @property
+    def autoorient(self):
+      return self.options["autoorient"]
 
     def copy(self):
         source, target = os.path.join(self.base_dir, self.name), os.path.join(self.target_dir, self.name)

--- a/prosopopee/prosopopee.py
+++ b/prosopopee/prosopopee.py
@@ -144,6 +144,10 @@ def main():
         global DEFAULT_GM_AUTOORIENT
         DEFAULT_GM_AUTOORIENT = settings.get("auto-orient")
 
+    if settings.get("quality"):
+      global DEFAULT_GM_QUALITY
+      DEFAULT_GM_QUALITY = settings.get("quality")
+
     front_page_galleries_cover = []
 
     dirs = filter(lambda x: x not in (".", "..") and os.path.isdir(x) and os.path.exists(os.path.join(os.getcwd(), x, "settings.yaml")), os.listdir(os.getcwd()))

--- a/prosopopee/prosopopee.py
+++ b/prosopopee/prosopopee.py
@@ -14,6 +14,7 @@ gallery_index_template = templates.get_template("gallery-index.html")
 page_template = templates.get_template("page.html")
 
 DEFAULT_GM_QUALITY = 75
+DEFAULT_GM_AUTOORIENT = False
 
 CACHE_VERSION = 1
 
@@ -72,6 +73,7 @@ class Image(object):
 
         self.name = name
         self.quality = options.get("quality", DEFAULT_GM_QUALITY)
+        self.autoorient = options.get("auto-orient", DEFAULT_GM_AUTOORIENT)
         self.options = options.copy()  # used for caching, if it's modified -> regenerate
         del self.options["name"]
 
@@ -82,9 +84,14 @@ class Image(object):
         # if os.path.exists(target) and os.path.getsize(source) == os.path.getsize(target):
             # print "Skipped %s since the file hasn't been modified based on file size" % source
             # return ""
-        shutil.copyfile(source, target)
+        if not self.autoorient:
+            shutil.copyfile(source, target)
+            print source, "->", target
+        else:
+            command = "gm convert -auto-orient %s %s" % (source, target)
+            print command
+            os.system(command)
 
-        print source, "->", target
         return ""
 
     def generate_thumbnail(self, gm_geometry):
@@ -95,7 +102,10 @@ class Image(object):
         source, target = os.path.join(self.base_dir, self.name), os.path.join(self.target_dir, thumbnail_name)
 
         if CACHE.thumbnail_needs_to_be_generated(source, target, self):
-            command = "gm convert %s -resize %s -quality %s %s" % (source, gm_geometry, self.quality, target)
+            gm_options = ""
+            if self.autoorient:
+              gm_options = "-auto-orient "
+            command = "gm convert %s %s -resize %s -quality %s %s" % (gm_options, source, gm_geometry, self.quality, target)
             print command
             os.system(command)
             CACHE.cache_thumbnail(source, target, self)
@@ -129,6 +139,10 @@ def main():
 
     error(isinstance(settings, dict), "Your settings.yaml should be a dict")
     error(settings.get("title"), "You should specify a title in your main settings.yaml")
+
+    if settings.get("auto-orient"):
+        global DEFAULT_GM_AUTOORIENT
+        DEFAULT_GM_AUTOORIENT = settings.get("auto-orient")
 
     front_page_galleries_cover = []
 

--- a/prosopopee/prosopopee.py
+++ b/prosopopee/prosopopee.py
@@ -100,7 +100,7 @@ class Image(object):
             shutil.copyfile(source, target)
             print source, "->", target
         else:
-            command = "gm convert %s -auto-orient -strip %s" % (source, target)
+            command = "gm convert %s -strip -auto-orient %s" % (source, target)
             print command
             os.system(command)
 

--- a/prosopopee/prosopopee.py
+++ b/prosopopee/prosopopee.py
@@ -16,6 +16,11 @@ page_template = templates.get_template("page.html")
 DEFAULT_GM_QUALITY = 75
 DEFAULT_GM_AUTOORIENT = False
 
+gm_settings = {
+  "quality" : 75,
+  "auto-orient" : True
+}
+
 CACHE_VERSION = 1
 
 
@@ -69,13 +74,8 @@ class Image(object):
         # assuming string
         if not isinstance(options, dict):
             options = {"name": options}
-
-        if not options.has_key("quality"):
-            options["quality"] = DEFAULT_GM_QUALITY
-        if not options.has_key("autoorient"):
-            options["autoorient"] = DEFAULT_GM_AUTOORIENT
-
         self.options = options.copy()  # used for caching, if it's modified -> regenerate
+        self.options.update(gm_settings)
 
     @property
     def name(self):
@@ -87,7 +87,7 @@ class Image(object):
 
     @property
     def autoorient(self):
-      return self.options["autoorient"]
+      return self.options["auto-orient"]
 
     def copy(self):
         source, target = os.path.join(self.base_dir, self.name), os.path.join(self.target_dir, self.name)
@@ -151,15 +151,10 @@ def main():
 
     error(isinstance(settings, dict), "Your settings.yaml should be a dict")
     error(settings.get("title"), "You should specify a title in your main settings.yaml")
-
-    if settings.get("auto-orient"):
-        global DEFAULT_GM_AUTOORIENT
-        DEFAULT_GM_AUTOORIENT = settings.get("auto-orient")
-
-    if settings.get("quality"):
-      global DEFAULT_GM_QUALITY
-      DEFAULT_GM_QUALITY = settings.get("quality")
-
+    
+    if settings.get("gm_settings"):
+        gm_settings.update( settings.get("gm_settings") )
+ 
     front_page_galleries_cover = []
 
     dirs = filter(lambda x: x not in (".", "..") and os.path.isdir(x) and os.path.exists(os.path.join(os.getcwd(), x, "settings.yaml")), os.listdir(os.getcwd()))


### PR DESCRIPTION
-auto-orient fixes orientation of pictures with an Orientation EXIF tag to make them straight (though it does not seem to update the EXIF tag itself to reflect that...).

-strip helps to drastically reduce file size by removing metadata for which we don't care, all the more for thumbnails (i see 15 MB->6.6 MB reduction for an input dir)
