### PR TITLE
[enh] add show_date setting, to be able to order galleries

### DIFF
--- a/prosopopee/prosopopee.py
+++ b/prosopopee/prosopopee.py
@@ -16,6 +16,7 @@ gallery_index_template = templates.get_template("gallery-index.html")
 page_template = templates.get_template("page.html")
 
 SETTINGS = {
+    "show_date": True,
     "gm": {
         "quality": 75,
         "auto-orient": True

--- a/prosopopee/templates/index.html
+++ b/prosopopee/templates/index.html
@@ -19,7 +19,7 @@
         <div class="gallery-title">
           <h2>{{ gallery.title }}</h2>
           {% if gallery.sub_title %}<h3>{{ gallery.sub_title }}</h3>{% endif %}
-          {% if gallery.date %}<div class="gallery-datetime">{{ gallery.date.strftime("%d %B %Y") }}</div>{% endif %}
+          {% if settings.show_date %}{% if gallery.date %}<div class="gallery-datetime">{{ gallery.date.strftime("%d %B %Y") }}</div>{% endif %}{% endif %}
           {% if gallery.tags %}<div class="gallery-tag">IN {% for tag in gallery.tags -%} <span>{{ tag }}</span> {% endfor -%}</div>{% endif %}
         </div>
       </a>

--- a/prosopopee/templates/index.html
+++ b/prosopopee/templates/index.html
@@ -19,7 +19,7 @@
         <div class="gallery-title">
           <h2>{{ gallery.title }}</h2>
           {% if gallery.sub_title %}<h3>{{ gallery.sub_title }}</h3>{% endif %}
-          {% if settings.show_date %}{% if gallery.date %}<div class="gallery-datetime">{{ gallery.date.strftime("%d %B %Y") }}</div>{% endif %}{% endif %}
+          {% if settings.show_date and if gallery.date %}<div class="gallery-datetime">{{ gallery.date.strftime("%d %B %Y") }}</div>{% endif %}
           {% if gallery.tags %}<div class="gallery-tag">IN {% for tag in gallery.tags -%} <span>{{ tag }}</span> {% endfor -%}</div>{% endif %}
         </div>
       </a>

--- a/prosopopee/templates/index.html
+++ b/prosopopee/templates/index.html
@@ -19,7 +19,7 @@
         <div class="gallery-title">
           <h2>{{ gallery.title }}</h2>
           {% if gallery.sub_title %}<h3>{{ gallery.sub_title }}</h3>{% endif %}
-          {% if settings.show_date and if gallery.date %}<div class="gallery-datetime">{{ gallery.date.strftime("%d %B %Y") }}</div>{% endif %}
+          {% if settings.show_date and gallery.date %}<div class="gallery-datetime">{{ gallery.date.strftime("%d %B %Y") }}</div>{% endif %}
           {% if gallery.tags %}<div class="gallery-tag">IN {% for tag in gallery.tags -%} <span>{{ tag }}</span> {% endfor -%}</div>{% endif %}
         </div>
       </a>


### PR DESCRIPTION
without showing the date

This allows (by chance) date keys to have non-date values, they just need to be comparable.
