### PR TITLE
Fix caption alignment on exposure theme

### DIFF
--- a/prosopopee/themes/exposure/static/css/style-page.css
+++ b/prosopopee/themes/exposure/static/css/style-page.css
@@ -241,7 +241,7 @@ footer a {
     font-family: "adobe-garamond-pro", serif;
     font-weight: normal;
     font-style: italic;
-    padding: 2px 20px;
+    padding: 2px 0px;
     width: 100%;
     text-align: center;
 }


### PR DESCRIPTION
it was always shifted to the right
