### PR TITLE
Add a new gm setting to allow progressive JPEG

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -63,6 +63,7 @@ Currently a `gm` settings key allows to customize the default GraphicsMagick's b
         auto-orient: True
         strip: True
         resize: 50%
+        progressive: True
 
 The meaning of the currently supported GraphicsMagick's settings is as follows:
 
@@ -70,6 +71,7 @@ The meaning of the currently supported GraphicsMagick's settings is as follows:
  * `auto-orient` change the orientation of pictures so they are upright (based on corresponding EXIF tags if present)
  * `strip` removes all profiles and text attributes from the image (good for privacy, slightly reduce file size)
  * `resize` can be used to resize the fullsize version of pictures. by default, input image size is preserved
+ * `progressive` converts classic baseline JPEG files to progressive JPEG, and interlace PNG/GIF files (improve the page loading impression, slightly reduce file size)
 
 Any GraphicsMagick setting can be customized on a per-image basis (either `cover` or `image`, see below).
 

--- a/prosopopee/prosopopee.py
+++ b/prosopopee/prosopopee.py
@@ -22,7 +22,8 @@ SETTINGS = {
         "quality": 75,
         "auto-orient": True,
         "strip": True,
-        "resize": None
+        "resize": None,
+        "progressive": True
     },
     "ffmpeg": {
         "binary": "ffmpeg",
@@ -138,10 +139,11 @@ class Image(object):
            "auto-orient": "-auto-orient" if options["auto-orient"] else "",
            "strip": "-strip" if options["strip"] else "",
            "quality": "-quality %s" % options["quality"] if "quality" in options else "-define jpeg:preserve-settings",
-           "resize": "-resize %s" % options["resize"] if options.get("resize", None) is not None else ""
+           "resize": "-resize %s" % options["resize"] if options.get("resize", None) is not None else "",
+           "progressive": "-interlace Line" if options.get("progressive", None) is True else ""
         }
 
-        command = "gm convert {source} {auto-orient} {strip} {quality} {resize} {target}".format(**gm_switches)
+        command = "gm convert {source} {auto-orient} {strip} {progressive} {quality} {resize} {target}".format(**gm_switches)
         warning("Generation", source)
 
         print(command)


### PR DESCRIPTION
I've added a new gm setting to offer the opportunity to convert all the JPEG files from the standard baseline loading to progressive.
This doesn't affect the file size (or just reduce it very slightly, nothing extraordinary), but give the illusion that the picture loads faster by having quickly a first _preview_ of it (which improve the user experience when using a slow connection).
For more details on progressive JPEG, this blog post is quite interesting : http://yuiblog.com/blog/2008/12/05/imageopt-4/
