### PR TITLE
themes: fix URI matching used for deciding if URI's local in menu

### DIFF
--- a/prosopopee/themes/exposure/templates/menu.html
+++ b/prosopopee/themes/exposure/templates/menu.html
@@ -4,7 +4,8 @@
       {% for line in settings.menu %}
       {% set rowloop = loop %}
       {% for file_name, menu_name in line.items() %}
-      {% if file_name.startswith('http') %}
+      {# We test if it's a URI reference or not #}
+      {% if ':' in file_name and not file_name.startswith('./') %}
       {% set file_name = file_name %}
       {% else %}
       {% set file_name = "../"+file_name %}

--- a/prosopopee/themes/light/templates/menu.html
+++ b/prosopopee/themes/light/templates/menu.html
@@ -3,7 +3,8 @@
     <ul>
       {% for line in settings.menu %}
       {% set file_name, menu_name = line.items()[0] %}
-      {% if file_name.startswith('http') %}
+      {# We test if it's a URI reference or not #}
+      {% if ':' in file_name and not file_name.startswith('./') %}
         {% set file_name = file_name %}
       {% elif gallery %}
         {% set file_name = "../"+file_name %}

--- a/prosopopee/themes/material/templates/menu.html
+++ b/prosopopee/themes/material/templates/menu.html
@@ -2,7 +2,8 @@
   {% for line in settings.menu %}
   {% set rowloop = loop %}
   {% for file_name, menu_name in line.items() %}
-  {% if file_name.startswith('http') %}
+  {# We test if it's a URI reference or not #}
+  {% if ':' in file_name and not file_name.startswith('./') %}
   {% set file_name = file_name %}
   {% else %}
   {% set file_name = "../"+file_name %}
@@ -16,7 +17,8 @@
   {% for line in settings.menu %}
   {% set rowloop = loop %}
   {% for file_name, menu_name in line.items() %}
-  {% if file_name.startswith('http') %}
+  {# We test if it's a URI reference or not #}
+  {% if ':' in file_name and not file_name.startswith('./') %}
   {% set file_name = file_name %}
   {% else %}
   {% set file_name = "../"+file_name %}


### PR DESCRIPTION
We want to distinguish between URI references ("local" pages), such as
path/to/another/page/of/my/website, from the other ones, such as
https://example.com in the menu to know how to build the URL.

The issue is that we did the distinction between the two by checking if
the string starts with "http".
Unfortunately, it does not match other valid URI schemes. One example is
mailto:address@example.com to open a mail client with the recipient
being address@example.com.
There are many other valid URI schemes (tel, ftp, irc, ...).
Under the current code, we think anything that isn't started by "http"
is local, i.e. we need to append the string to the parent path of the
current page.
This means that we have
https://mywebsite.example.com/mailto:address@example.com linked in the
menu instead of the expected mailto:address@example.com.

Let's fix that with a very simple test. A URI reference is commonly
detected as anything that does not contain a scheme (which has to be
suffixed by ':') or if it does, that the given path starts with './'.

This is most likely not handling all the cases but at least most of the
common ones.

Please refer to the RFC for further information:
https://www.rfc-editor.org/rfc/rfc3986.txt

Signed-off-by: Quentin Schulz <foss@0leil.net>