### PR TITLE
Fix alignment issue when pictures do not fill the pictures-group line

### DIFF
--- a/prosopopee/prosopopee.py
+++ b/prosopopee/prosopopee.py
@@ -16,6 +16,7 @@ Options:
 import os
 import shutil
 import socketserver
+import subprocess
 import http.server
 
 import ruamel.yaml as yaml
@@ -265,6 +266,13 @@ class Image(object):
             self.gm(source, target, options)
 
         return thumbnail_name
+
+    @property
+    def ratio(self):
+        command = "gm identify -format %w,%h " + self.base_dir.joinpath(self.name)
+        out = subprocess.check_output(command.split())
+        width,height = out.split(',')
+        return float(width) / int(height)
 
     def __repr__(self):
         return self.name

--- a/prosopopee/prosopopee.py
+++ b/prosopopee/prosopopee.py
@@ -140,6 +140,17 @@ class Video(object):
 
         return thumbnail_name
 
+    @property
+    def ratio(self):
+        if self.options["binary"] == "ffmpeg":
+            binary = "ffprobe"
+        else:
+            binary = "avprobe"
+        command = binary + " -v error -select_streams v:0 -show_entries stream=width,height -of csv=p=0 " + self.base_dir.joinpath(self.name)
+        out = subprocess.check_output(command.split())
+        width,height = out.split(',')
+        return float(width) / int(height)
+
     def __repr__(self):
         return self.name
 

--- a/prosopopee/themes/exposure/templates/sections/pictures-group.html
+++ b/prosopopee/themes/exposure/templates/sections/pictures-group.html
@@ -5,12 +5,19 @@
     {% for line in section.images %}
     <div class="pictures-line">
       {% for image in line %}
-      <div class="picture caption">
+      {% set caption = image.text %}
+      {% if image.type == "video" %}
+      {% set video = Video(image) %}
+      {% set format = settings.ffmpeg.extension %}
+      {{ video.copy() }}
+      {% set ratio = video.ratio %}
+      {% else %}
+      {% set image = Image(image) %}
+      {{ image.copy() }}
+      {% set ratio = image.ratio %}
+      {% endif %}
+      <div class="picture caption" style="flex-grow: {{ ratio }}">
         {% if image.type == "video" %}
-        {% set caption = image.text %}
-        {% set video = Video(image) %}
-        {% set format = settings.ffmpeg.extension %}
-        {{ video.copy() }}
         <img class="lazy" data-original="{{ video.generate_thumbnail("600") }}" src="" alt="">
         <video class="lazy responsive-video" id="{{ video }}" onclick="goFullscreen('{{ video }}');" poster="{{ video.generate_thumbnail("600") }}" alt="" autoplay="autoplay" loop="loop" preload="auto" muted>
           <source src="{{ video }}.{{ format }}" type="video/{{ format }}">
@@ -21,9 +28,6 @@
         </div>
         {% endif %}
         {% else %}
-        {% set caption = image.text %}
-        {% set image = Image(image) %}
-        {{ image.copy() }}
         <a href="{{ image }}" {% if caption %}data-caption="{{ caption }}"{% endif %}
            data-at-450="{{ image.generate_thumbnail("x450") }}"
            data-at-800="{{ image.generate_thumbnail("x800") }}"

--- a/prosopopee/themes/material/templates/sections/pictures-group.html
+++ b/prosopopee/themes/material/templates/sections/pictures-group.html
@@ -5,12 +5,19 @@
     {% for line in section.images %}
     <div class="pictures-line">
       {% for image in line %}
-      <div class="picture caption">
+      {% set caption = image.text %}
+      {% if image.type == "video" %}
+      {% set video = Video(image) %}
+      {% set format = settings.ffmpeg.extension %}
+      {{ video.copy() }}
+      {% set ratio = video.ratio %}
+      {% else %}
+      {% set image = Image(image) %}
+      {{ image.copy() }}
+      {% set ratio = image.ratio %}
+      {% endif %}
+      <div class="picture caption" style="flex-grow: {{ ratio }}">
         {% if image.type == "video" %}
-        {% set caption = image.text %}
-        {% set video = Video(image) %}
-        {% set format = settings.ffmpeg.extension %}
-        {{ video.copy() }}
         <img class="z-depth-2 lazy responsive-img" data-original="{{ video.generate_thumbnail("600") }}" src="" alt="">
         <video class="lazy responsive-video" id="{{ video }}" onclick="goFullscreen('{{ video }}');" poster="{{ video.generate_thumbnail("600") }}" alt="" autoplay="autoplay" loop="loop" preload="auto" muted>
           <source src="{{ video }}.{{ format }}" type="video/{{ format }}">
@@ -21,9 +28,6 @@
         </div>
         {% endif %}
         {% else %}
-        {% set caption = image.text %}
-        {% set image = Image(image) %}
-        {{ image.copy() }}
         <a href="{{ image }}" {% if caption %}data-caption="{{ caption }}"{% endif %}
            data-at-450="{{ image.generate_thumbnail("x450") }}"
            data-at-800="{{ image.generate_thumbnail("x800") }}"


### PR DESCRIPTION
When pictures are too small to fill a pictures-group's line (which can happen with two portrait pictures; for example on a 1080p screen since the pictures are x600 thumbnails, only two portrait pictures in one line would make the content of the line ~1200px instead of the ~1920px (it's actually with the current syle.css 77% of that => ~1500px) of available space.

![Alignment issue](https://user-images.githubusercontent.com/4410071/57198936-445a3800-6f79-11e9-9eb9-ec875c9ad687.png)

The issue is particularly present when zooming out:
![Alignment issue zooming out](https://user-images.githubusercontent.com/4410071/57198949-71a6e600-6f79-11e9-8b19-80a6ca3eab26.png)

I'd expect the pictures to fill the whole line.

With the fix:
![Fixed alignment](https://user-images.githubusercontent.com/4410071/57199135-e8dd7980-6f7b-11e9-8c4f-1aee569f7355.png)

Fixes #92 