### PR TITLE
Localization of human-readable dates

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -251,7 +251,8 @@ For example, if your LC_TIME equals to en_US.utf8, then you get "23 August 2020"
 
 If you want to use non-based on LC_TIME locale for human-readable dates on gallery, use the "date_locale" key::
 
-  date_locale: ru_RU
+  settings:
+    date_locale: ru_RU
 
 Gallery settings.yaml
 ---------------------

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -242,6 +242,17 @@ If you want to protect all the website by password::
   title: Gallery
   password: my_super_password
 
+Date locale
+~~~~~~~~~~~
+
+By default, Prosopopee uses locale from LC_TIME environment variable to generate human-readable date.
+
+For example, if your LC_TIME equals to en_US.utf8, then you get "23 August 2020" as date on the gallery tile. If you are using ru_RU.utf8, then you get "23 Августа 2020".
+
+If you want to use non-based on LC_TIME locale for human-readable dates on gallery, use the "date_locale" key::
+
+  date_locale: ru_RU
+
 Gallery settings.yaml
 ---------------------
 

--- a/prosopopee/themes/exposure/templates/index.html
+++ b/prosopopee/themes/exposure/templates/index.html
@@ -36,7 +36,7 @@
         <div class="gallery-title">
           <h2>{{ gallery.title }}</h2>
           {% if gallery.sub_title %}<h3>{{ gallery.sub_title }}</h3>{% endif %}
-          {% if settings.show_date and gallery.date %}<div class="gallery-datetime">{{ gallery.date.strftime("%d %B %Y") }}</div>{% endif %}
+          {% if settings.show_date and gallery.date %}<div class="gallery-datetime">{{ gallery.date|local_date("dd MMMM yyyy") }}</div>{% endif %}
           {% if gallery.tags %}<div class="gallery-tag">IN {% for tag in gallery.tags -%} <span> {{ tag }}</span> {% endfor -%}</div>{% endif %}
         </div>
       </a>

--- a/prosopopee/themes/exposure/templates/sections/full-picture.html
+++ b/prosopopee/themes/exposure/templates/sections/full-picture.html
@@ -10,10 +10,10 @@
         <h1>{{ section.text.title }}</h1>
         <h2>{{ section.text.sub_title }}</h2>
         {% if section.text.date_end %}
-        <div class="datetime">{{ section.text.date.strftime("%d %B %Y") }}  to {{ section.text.date_end.strftime("%d %B %Y") }}</div>
+        <div class="datetime">{{ section.text.date|local_date("dd MMMM yyyy") }}  to {{ section.text.date_end|local_date("dd MMMM yyyy") }}</div>
         {% else %}
         {% if section.text.date %}
-        <div class="datetime">{{ section.text.date.strftime("%d %B %Y") }}</div>{% endif %}
+        <div class="datetime">{{ section.text.date|local_date("dd MMMM yyyy") }}</div>{% endif %}
         {% endif %}
       </div>
     </div>
@@ -34,10 +34,10 @@
       <h1>{{ section.text.title }}</h1>
       <h2>{{ section.text.sub_title }}</h2>
       {% if section.text.date_end %}
-      <div class="datetime">{{ section.text.date.strftime("%d %B %Y") }}  to {{ section.text.date_end.strftime("%d %B %Y") }}</div>
+      <div class="datetime">{{ section.text.date|local_date("dd MMMM yyyy") }}  to {{ section.text.date_end|local_date("dd MMMM yyyy") }}</div>
       {% else %}
       {% if section.text.date %}
-      <div class="datetime">{{ section.text.date.strftime("%d %B %Y") }}</div>{% endif %}
+      <div class="datetime">{{ section.text.date|local_date("dd MMMM yyyy") }}</div>{% endif %}
       {% endif %}
     </div>
   </div>

--- a/prosopopee/themes/light/templates/index.html
+++ b/prosopopee/themes/light/templates/index.html
@@ -30,7 +30,7 @@
         <div class="gallery-title">
             <h2>{{ gallery.title }}</h2>
           {% if gallery.sub_title %}<h3>{{ gallery.sub_title }}</h3>{% endif %}
-          {% if settings.show_date and gallery.date %}<div class="gallery-datetime">{{ gallery.date.strftime("%d %B %Y") }}</div>{% endif %}
+          {% if settings.show_date and gallery.date %}<div class="gallery-datetime">{{ gallery.date|local_date("dd MMMM yyyy") }}</div>{% endif %}
           {% if gallery.tags %}<div class="gallery-tag">IN {% for tag in gallery.tags %} <span> {{ tag }}</span> {% endfor %}</div>{% endif %}
         </div>
       </a>

--- a/prosopopee/themes/light/templates/sections/full-picture.html
+++ b/prosopopee/themes/light/templates/sections/full-picture.html
@@ -25,10 +25,10 @@
     <h1>{{ section.text.title }}</h1>
     <h2>{{ section.text.sub_title }}</h2>
     {% if section.text.date_end %}
-    <div class="datetime">{{ section.text.date.strftime("%d %B %Y") }}  to {{ section.text.date_end.strftime("%d %B %Y") }}</div>
+    <div class="datetime">{{ section.text.date|local_date("dd MMMM yyyy") }}  to {{ section.text.date_end|local_date("dd MMMM yyyy") }}</div>
     {% else %}
     {% if section.text.date %}
-    <div class="datetime">{{ section.text.date.strftime("%d %B %Y") }}</div>{% endif %}
+    <div class="datetime">{{ section.text.date|local_date("dd MMMM yyyy") }}</div>{% endif %}
     {% endif %}
     {% endif %}
 </div>

--- a/prosopopee/themes/material/templates/index.html
+++ b/prosopopee/themes/material/templates/index.html
@@ -20,7 +20,7 @@
         <div class="gallery-title">
           <h2>{{ gallery.title }}</h2>
           {% if gallery.sub_title %}<h3>{{ gallery.sub_title }}</h3>{% endif %}
-          {% if settings.show_date and gallery.date %}<div class="gallery-datetime">{{ gallery.date.strftime("%d %B %Y") }}</div>{% endif %}
+          {% if settings.show_date and gallery.date %}<div class="gallery-datetime">{{ gallery.date|local_date("dd MMMM yyyy") }}</div>{% endif %}
           {% if gallery.tags %}<div class="gallery-tag">IN {% for tag in gallery.tags -%} <span> {{ tag }}</span> {% endfor -%}</div>{% endif %}
         </div>
       </a>

--- a/prosopopee/themes/material/templates/sections/full-picture.html
+++ b/prosopopee/themes/material/templates/sections/full-picture.html
@@ -20,11 +20,11 @@
     <h2>{{ section.text.sub_title }}</h2>
 
     {% if section.text.date_end %}
-    <div class="datetime">{{ section.text.date.strftime("%d %B %Y") }}  to {{ section.text.date_end.strftime("%d %B %Y") }}</div>
+    <div class="datetime">{{ section.text.date|local_date("dd MMMM yyyy") }}  to {{ section.text.date_end|local_date("dd MMMM yyyy") }}</div>
 
     {% else %}
     {% if section.text.date %}
-    <div class="datetime">{{ section.text.date.strftime("%d %B %Y") }}</div>
+    <div class="datetime">{{ section.text.date|local_date("dd MMMM yyyy") }}</div>
     {% endif %}
     {% endif %}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+Babel
 jinja2
 path.py
 docopt


### PR DESCRIPTION
Hello.
I found what human-readable dates on the main page of Prosopopee-based gallery are always in English language disregarding to locale settings of my OS.
So, I do some changes and now Prosopopee watches to LC_TIME environment variable before format human-readable dates. For example:

- If you use LC_TIME=en_US.utf8 — you will get dates like «23 August 2020» on the your browser with opened gallery;
- If you use LC_TIME=ru_RU.utf8 — you will get «23 Августа 2020»;

For users, who want to have human-readable dates not based on LC_TIME environment variable — I add key «date_locale» for Prosopopee settings.