### PR TITLE
Fix autogen bugs

### DIFF
--- a/prosopopee/autogen.py
+++ b/prosopopee/autogen.py
@@ -41,8 +41,8 @@ def get_exif(filename):
         for (tag, value) in exif.items():
             decoded = TAGS.get(tag, tag)
             exif_data[decoded] = value
-        if 'DateTime' in exif_data:
-            datetime = exif_data['DateTime']
+    if 'DateTime' in exif_data:
+        datetime = exif_data['DateTime']
     else:
         datetime = strftime("%Y:%m:%d %H:%M:00", gmtime(os.path.getmtime(filename)))
     return datetime

--- a/prosopopee/autogen.py
+++ b/prosopopee/autogen.py
@@ -17,14 +17,12 @@ sections:
 {% set nb = namespace(value=range(2,5)|random) %}
 {% set count = namespace(value=0) %}
 {% for file in files %}
-{% if count.value != nb.value %}
 {% set file = file.split('/') %}
          - {{ file[-1] }}
+{% if count.value != nb.value %}
 {% set count.value = count.value + 1 %}
-{% else %}
-{% if not loop.last %}
+{% elif not loop.last %}
       -
-{% endif %}
 {% set count.value = 0 %}
 {% set nb. value = range(2,5)|random %}
 {% endif %}


### PR DESCRIPTION
If exif data exists but 'DateTime' is not in exif_data, the datetime
that we're supposed to return never gets assigned and triggers an Error.

We first attempt to populate the exif_data and then IF it's populated we
use it ELSE we use getmtime so it's always one or the other. No error
here because exif_data is already initialized as {}.

resolves #112