### PR TITLE
full-picture: enable background-position customization

### DIFF
--- a/docs/sections.rst
+++ b/docs/sections.rst
@@ -51,6 +51,17 @@ If you want a fixed background you can use this option (only with the exposure t
   - type: full-picture
     fixed: true
 
+The `background_position` setting can be used to control how the image is centered when
+it doesn't fit the screen width. This is useful for controlling the center accross different
+screen sizes (e.g. mobile), keeping the focal element of an image always visible.
+This sets the `background-position` css property.
+This feature is supported by the "exposure" theme.
+Example::
+
+  - type: full-picture
+    image: big_picture.jpg
+    background_position: 75%
+
 Bordered picture
 ________________
 

--- a/prosopopee/themes/exposure/templates/sections/full-picture.html
+++ b/prosopopee/themes/exposure/templates/sections/full-picture.html
@@ -27,7 +27,7 @@
 {% else %}
 {% set image = Image(section.image) %}
 {{ image.copy() }}
-<section class="lazy full-picture" data-bg="url({{ image.generate_thumbnail("x2000") }})" style="background-position: 50% 50%; background-repeat: no-repeat; background-attachment: {% if section.fixed %} fixed {% else %} scroll {% endif %};background-size: cover;">
+<section class="lazy full-picture" data-bg="url({{ image.generate_thumbnail("x2000") }})" style="background-position: {% if section.background_position %} {{ section.background_position }} {% else %} 50% 50%{% endif %}; background-repeat: no-repeat; background-attachment: {% if section.fixed %} fixed {% else %} scroll {% endif %};background-size: cover;">
   {% if section.text %}
   <div class="picture-text">
     <div class="picture-text-column animated animatedFadeInUp fadeInUp">


### PR DESCRIPTION
The `background_position` setting can be used to control how the image is centered when
it doesn't fit the screen width. This is useful for controlling the center accross different
screen sizes (e.g. mobile), keeping the focal element of an image always visible.
This sets the `background-position` css property.
This feature is supported by the "exposure" theme.
Example:

```yaml
  - type: full-picture
    image: big_picture.jpg
    background_position: 75%
```

I feel this feature is essential for the way I want to use full pictures in my galleries. Anybody can just add it as their custom theme but I thought I'd send a PR because it's a simple and easy way to give users more creative control over their albums.