### PR TITLE
Fix sorting when DateTime is not in the EXIF data

### DIFF
--- a/prosopopee/autogen.py
+++ b/prosopopee/autogen.py
@@ -6,7 +6,6 @@ from glob import glob
 from jinja2 import Template
 from path import Path
 from PIL import Image
-from PIL.ExifTags import TAGS
 
 from .utils import load_settings
 

--- a/prosopopee/autogen.py
+++ b/prosopopee/autogen.py
@@ -36,12 +36,12 @@ types = ("*.JPG", "*.jpg", "*.JPEG", "*.jpeg", "*.png", "*.PNG")
 
 
 def get_exif(filename):
-    exif = Image.open(filename)._getexif()
+    exif = Image.open(filename).getexif()
     if exif is not None:
-        for tag in exif:
-            decoded = TAGS.get(tag, tag)
-            if decoded == "DateTime":
-                return exif[tag]
+        # DateTimeOriginal, DateTimeDigitized, DateTime(DateTimeModified)
+        ctime = exif.get(0x9003, exif.get(0x9004, exif.get(0x0132)))
+        if ctime is not None:
+            return ctime
 
     return strftime("%Y:%m:%d %H:%M:00", gmtime(os.path.getmtime(filename)))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ jinja2
 path.py
 ruamel.yaml
 future
-pillow
+pillow>=6


### PR DESCRIPTION
Get in priority DateTimeOriginal to sort file as specified by the EXIF documentation.
If there is no DateTimeOriginal  fallback to DateTimeDigitized and then DateTime.