### PR TITLE
Migration to Pillow and huge performance improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 dist: xenial
 language: python
 install:
-  - sudo apt-get install graphicsmagick libav-tools -y
+  - sudo apt-get install libav-tools -y
   - pip3 install -r requirements.txt
   - pip3 install tox
   - python setup.py develop
@@ -12,7 +12,6 @@ python:
   - "3.6"
 script:
   - tox
-  - gm -version
   - cd example && prosopopee
 notifications:
   irc: "chat.freenode.net#prosopopee"

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -68,7 +68,7 @@ Global settings can be put in your root `settings.yaml`, under the `settings` ke
 GM
 ~~
 
-Currently a `gm` setting key allows to customize the default GraphicsMagick's behaviour. It looks like::
+Currently a `gm` setting key allows to customize the default behaviour for thumbnail creation. It looks like::
 
   title: Gallery
   settings:
@@ -79,7 +79,7 @@ Currently a `gm` setting key allows to customize the default GraphicsMagick's be
       resize: 50%
       progressive: True
 
-The meaning of the currently supported GraphicsMagick's settings is as follows:
+The meaning of the currently supported settings is as follows:
 
  * `quality` allows to customize the compression level of thumbnails (between 0 and 100)
  * `auto-orient` changes the orientation of pictures so they are upright (based on corresponding EXIF tags if present)
@@ -87,7 +87,7 @@ The meaning of the currently supported GraphicsMagick's settings is as follows:
  * `resize` can be used to resize the full-size version of pictures. By default, input image size is preserved
  * `progressive` converts classic baseline JPEG files to progressive JPEG, and interlaces PNG/GIF files (improves the page loading impression, slightly reduces file size)
 
-Any GraphicsMagick setting can be customized on a per-image basis (either `cover` or `image`, see below).
+Any of thumbnail creation settings can be customized on a per-image basis (either `cover` or `image`, see below).
 
 Video converter
 ~~~~~~~~~~~~~~~

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -11,12 +11,7 @@ We need Python, pip and virtualenv::
 
     apt-get install python3-pip python3-virtualenv
 
-and graphicsmagick library for building the gallery::
-
-    # graphicsmagick requires to have the 5.3.1 version of gcc-5-base
-    apt-get install graphicsmagick
-
-A video converter like ffmpeg::
+And a video converter like ffmpeg::
 
     apt-get install ffmpeg
 
@@ -35,11 +30,7 @@ We need Brew::
 
   /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 
-and graphicsmagick library for building the gallery::
-
-  brew install graphicsmagick 
-  
-A video converter like ffmpeg::  
+And a video converter like ffmpeg::
   
   brew install ffmpeg
 

--- a/prosopopee/autogen.py
+++ b/prosopopee/autogen.py
@@ -31,6 +31,8 @@ sections:
 {% endfor %}
 """
 
+logger = logging.getLogger("prosopopee." + __name__)
+
 types = ("*.JPG", "*.jpg", "*.JPEG", "*.jpeg", "*.png", "*.PNG")
 
 
@@ -51,11 +53,11 @@ def build_template(folder, force):
     gallery_settings = load_settings(folder)
 
     if "static" in gallery_settings:
-        logging.info("Skipped: Nothing to do in %s gallery", folder)
+        logger.info("Skipped: Nothing to do in %s gallery", folder)
         return
 
     if any(req not in gallery_settings for req in ["title", "date", "cover"]):
-        logging.error(
+        logger.error(
             "You need configure first, the title, date and cover in %s/settings.yaml "
             "to use autogen",
             folder,
@@ -63,7 +65,7 @@ def build_template(folder, force):
         sys.exit(1)
 
     if "sections" in gallery_settings and force is not True:
-        logging.info("Skipped: %s gallery is already generated", folder)
+        logger.info("Skipped: %s gallery is already generated", folder)
         return
 
     for files in types:
@@ -77,7 +79,7 @@ def build_template(folder, force):
     )
     settings = open(Path(".").joinpath(folder, "settings.yaml").abspath(), "w")
     settings.write(msg)
-    logging.info("Generation: %s gallery", folder)
+    logger.info("Generation: %s gallery", folder)
 
 
 def autogen(folder=None, force=False):

--- a/prosopopee/cache.py
+++ b/prosopopee/cache.py
@@ -1,9 +1,13 @@
-import os
 import json
+import logging
+import os
 
 from .utils import remove_superficial_options
 
 CACHE_VERSION = 2
+
+
+logger = logging.getLogger("prosopopee." + __name__)
 
 
 class Cache:

--- a/prosopopee/cache.py
+++ b/prosopopee/cache.py
@@ -1,21 +1,9 @@
 import os
 import json
 
+from .utils import remove_superficial_options
+
 CACHE_VERSION = 2
-
-
-def remove_superficial_options(options):
-    cleaned_options = options.copy()
-    del cleaned_options["name"]
-    if "text" in cleaned_options:
-        del cleaned_options["text"]
-    if "type" in cleaned_options:
-        del cleaned_options["type"]
-    if "size" in cleaned_options:
-        del cleaned_options["size"]
-    if "float" in cleaned_options:
-        del cleaned_options["float"]
-    return cleaned_options
 
 
 class Cache:

--- a/prosopopee/cache.py
+++ b/prosopopee/cache.py
@@ -41,9 +41,15 @@ class Cache:
 
         cached_picture = self.cache[target]
 
-        if cached_picture["size"] != os.path.getsize(source) or cached_picture[
-            "options"
-        ] != remove_superficial_options(options):
+        if cached_picture["size"] != os.path.getsize(source):
+            return True
+
+        options = remove_superficial_options(options)
+        # json.dumps() transforms tuples into list, so to be able to compare options
+        # same transformation needs to be done on runtime dict.
+        options = json.loads(json.dumps(options))
+
+        if cached_picture["options"] != options:
             return True
 
         return False

--- a/prosopopee/cache.py
+++ b/prosopopee/cache.py
@@ -2,6 +2,8 @@ import json
 import logging
 import os
 
+from multiprocessing import Manager
+
 from .utils import remove_superficial_options
 
 CACHE_VERSION = 2
@@ -20,13 +22,15 @@ class Cache:
         # This wonderfully stupid behavior has been fixed in 3.4 (which nobody uses)
         self.json = json
         if os.path.exists(os.path.join(os.getcwd(), ".prosopopee_cache")):
-            self.cache = json.load(open(self.cache_file_path, "r"))
+            cache = json.load(open(self.cache_file_path, "r"))
         else:
-            self.cache = {"version": CACHE_VERSION}
+            cache = {"version": CACHE_VERSION}
 
-        if "version" not in self.cache or self.cache["version"] != CACHE_VERSION:
+        if "version" not in cache or cache["version"] != CACHE_VERSION:
             print("info: cache format as changed, prune cache")
-            self.cache = {"version": CACHE_VERSION}
+            cache = {"version": CACHE_VERSION}
+
+        self.cache = Manager().dict(cache)
 
     def needs_to_be_generated(self, source, target, options):
         if not os.path.exists(target):
@@ -51,7 +55,7 @@ class Cache:
         }
 
     def cache_dump(self):
-        self.json.dump(self.cache, open(self.cache_file_path, "w"))
+        self.json.dump(dict(self.cache), open(self.cache_file_path, "w"))
 
 
 CACHE = Cache(json=json)

--- a/prosopopee/cache.py
+++ b/prosopopee/cache.py
@@ -6,7 +6,7 @@ from multiprocessing import Manager
 
 from .utils import remove_superficial_options
 
-CACHE_VERSION = 2
+CACHE_VERSION = 3
 
 
 logger = logging.getLogger("prosopopee." + __name__)
@@ -34,14 +34,19 @@ class Cache:
 
     def needs_to_be_generated(self, source, target, options):
         if not os.path.exists(target):
+            logger.debug("%s does not exist. Requesting generation...", target)
             return True
 
         if target not in self.cache:
+            logger.debug("%s not in cache. Requesting generation...", target)
             return True
 
         cached_picture = self.cache[target]
 
         if cached_picture["size"] != os.path.getsize(source):
+            logger.debug(
+                "%s has different size than in cache. Requesting generation...", target
+            )
             return True
 
         options = remove_superficial_options(options)
@@ -50,8 +55,13 @@ class Cache:
         options = json.loads(json.dumps(options))
 
         if cached_picture["options"] != options:
+            logger.debug(
+                "%s has different options than in cache. Requesting generation...",
+                target,
+            )
             return True
 
+        logger.debug("(%s) Skipping cached thumbnail %s", source, target)
         return False
 
     def cache_picture(self, source, target, options):

--- a/prosopopee/image.py
+++ b/prosopopee/image.py
@@ -1,0 +1,106 @@
+import imagesize
+import logging
+import re
+import sys
+
+from json import dumps as json_dumps
+from pathlib import Path
+from zlib import crc32
+
+from .utils import remove_superficial_options
+
+
+logger = logging.getLogger("prosopopee." + __name__)
+
+
+class ImageCommon:
+    @property
+    def ratio(self):
+        # For when BaseImage.ratio is called before BaseImage.copy() is.
+        if not self.size:
+            self.size = imagesize.get(self.filepath)
+        width, height = self.size
+        return width / height
+
+
+class Thumbnail(ImageCommon):
+    def __init__(self, base_filepath, base_id, size):
+        self.filepath = self.__filepath(base_filepath, base_id, size)
+        self.size = size
+
+    def __filepath(self, base_filepath, base_id, size):
+        p = Path(base_filepath)
+        width, height = size
+        suffix = "-{base_id}-{width}x{height}{suffix}".format(
+            base_id=base_id,
+            width=width if width else "",
+            height=height if height else "",
+            suffix=p.suffix,
+        )
+
+        return p.parent / (p.stem + suffix)
+
+
+class BaseImage(ImageCommon):
+    re_rsz = re.compile(r"^(\d+)%$")
+
+    def __init__(self, options, global_options):
+        self.copysize = None
+        self.thumbnails = dict()
+        self.options = global_options.copy()
+        self.options.update(options)
+        self.filepath = self.options["name"]
+        self.resize = self.options.get("resize")
+        self.options = remove_superficial_options(self.options)
+        self.chksum_opt = crc32(
+            bytes(json_dumps(self.options, sort_keys=True), "utf-8")
+        )
+
+    def copy(self):
+        if not self.copysize:
+            width, height = imagesize.get(self.filepath)
+
+            if self.resize:
+                match = BaseImage.re_rsz.match(str(self.resize))
+                if not match:
+                    logger.error(
+                        "(%s) specified resize setting is not a percentage",
+                        self.filepath,
+                    )
+                    sys.exit(1)
+                percentage = int(match.group(1))
+                width, height = width * percentage // 100, height * percentage // 100
+
+            self.copysize = width, height
+
+        return self.thumbnail(self.copysize)
+
+    def thumbnail(self, size):
+        thumbnail = Thumbnail(self.filepath, self.chksum_opt, size)
+        return self.thumbnails.setdefault(thumbnail.filepath, thumbnail).filepath.name
+
+
+# TODO: add support for looking into parent directories (name: ../other_gallery/pic.jpg)
+class ImageFactory:
+    base_imgs = dict()
+    global_options = dict()
+
+    @classmethod
+    def get(cls, path, image):
+        if not isinstance(image, dict):
+            image = {"name": image}
+
+        if "name" not in image:
+            logger.error(
+                'At least one image in "%s" does not have a `name` property, please add the '
+                "filename of the image to a `name` property.",
+                path + "/settings.yaml",
+            )
+            sys.exit(1)
+
+        im = image.copy()
+        # To resolve paths with .. in them, we need to resolve the path first and then
+        # find the relative path to the source (current) directory.
+        im["name"] = Path(path).joinpath(im["name"]).resolve().relative_to(Path.cwd())
+        img = BaseImage(im, cls.global_options)
+        return cls.base_imgs.setdefault(img.filepath / str(img.chksum_opt), img)

--- a/prosopopee/prosopopee.py
+++ b/prosopopee/prosopopee.py
@@ -47,7 +47,15 @@ parser.add_argument(
     help="Configure the logging level",
 )
 subparser = parser.add_subparsers(dest="cmd")
-subparser.add_parser("build", help="Generate static site")
+parser_build = subparser.add_parser("build", help="Generate static site")
+parser_build.add_argument(
+    "-j",
+    "--jobs",
+    default=None,
+    type=int,
+    help="Specifies number of jobs (thumbnail generations) to run simultaneously. Default: number "
+    "of threads available on the system",
+)
 subparser.add_parser("test", help="Verify all your yaml data")
 subparser.add_parser("preview", help="Start preview webserver on port 9000")
 subparser.add_parser("deploy", help="Deploy your website")
@@ -923,7 +931,12 @@ def main():
         logger.info("Success: HTML file building without error")
         sys.exit(0)
 
-    with Pool() as pool:
+    # If prosopopee is started without any argument, 'build' is assumed but the jobs parameter
+    # is not part of the namespace, so set its default to None (or 'number of available CPU
+    # treads')
+    jobs = args.jobs if args.cmd else None
+
+    with Pool(jobs) as pool:
         # Pool splits the iterable into pre-defined chunks which are then assigned to processes.
         # There is no other scheduling in play after that. This is an issue when chunks are
         # outrageously unbalanced in terms of CPU time which happens when most galleries are

--- a/prosopopee/prosopopee.py
+++ b/prosopopee/prosopopee.py
@@ -880,10 +880,12 @@ def main():
         open(Path("build").joinpath("feed.xml"), "wb").write(xml)
 
     build_index(settings, front_page_galleries_cover, templates)
-    CACHE.cache_dump()
 
     if DEFAULTS["test"] is True:
         logging.info("Success: HTML file building without error")
+        sys.exit(0)
+
+    CACHE.cache_dump()
 
 
 if __name__ == "__main__":

--- a/prosopopee/themes/exposure/templates/index.html
+++ b/prosopopee/themes/exposure/templates/index.html
@@ -26,7 +26,7 @@
 {% block content %}
 <div class="galleries-grid">
   {% for galleries_line in galleries|reverse|batch(3)|reverse %}
-  {% if loop.index is divisibleby 3 or loop.index is divisibleby 2 %}
+  {% if galleries_line|length > 1 %}
   {% set no_big_gallery_cover = true %}
   {% endif %}
   <div class="galleries-line covers-{{ galleries_line|length }}">

--- a/prosopopee/themes/exposure/templates/index.html
+++ b/prosopopee/themes/exposure/templates/index.html
@@ -52,7 +52,6 @@
       </div>
       {% else %}
       {% set cover = Image(gallery.cover) %}
-      {{ cover.copy() }}
       {% if no_big_gallery_cover %}
       <div class="gallery-cover" style="background-image: url('{{ cover.generate_thumbnail("x900") }}'), url('{{ cover.generate_thumbnail("x150") }}');"></div>
       {% else %}

--- a/prosopopee/themes/exposure/templates/index.html
+++ b/prosopopee/themes/exposure/templates/index.html
@@ -32,7 +32,7 @@
   <div class="galleries-line covers-{{ galleries_line|length }}">
     {% for gallery in galleries_line|reverse %}<!-- comment tricks against space between inline-block
     --><div class="gallery-square">
-      <a href="{{ gallery.link }}">
+      <a href="{{ gallery.name }}">
         <div class="gallery-title">
           <h2>{{ gallery.title }}</h2>
           {% if gallery.sub_title %}<h3>{{ gallery.sub_title }}</h3>{% endif %}
@@ -51,11 +51,11 @@
         <img class="fillWidth" alt="" src="{{ video.generate_thumbnail("900") }}">
       </div>
       {% else %}
-      {% set cover = Image(gallery.cover) %}
+      {% set cover = Image.get(gallery.link, gallery.cover) %}
       {% if no_big_gallery_cover %}
-      <div class="gallery-cover" style="background-image: url('{{ cover.generate_thumbnail("x900") }}'), url('{{ cover.generate_thumbnail("x150") }}');"></div>
+      <div class="gallery-cover" style="background-image: url('{{ gallery.name }}/{{ cover.thumbnail((None, 900)) }}'), url('{{ gallery.name }}/{{ cover.thumbnail((None, 150)) }}');"></div>
       {% else %}
-      <div class="gallery-cover" style="background-image: url('{{ cover.generate_thumbnail("x1366") }}'), url('{{ cover.generate_thumbnail("x900") }}');"></div>
+      <div class="gallery-cover" style="background-image: url('{{ gallery.name }}/{{ cover.thumbnail((None, 1366)) }}'), url('{{ gallery.name }}/{{ cover.thumbnail((None, 900)) }}');"></div>
       {% endif %}
       {% endif %}
     </div><!-- comment tricks against space between inline-block

--- a/prosopopee/themes/exposure/templates/opengraph.html
+++ b/prosopopee/themes/exposure/templates/opengraph.html
@@ -1,7 +1,7 @@
 {% set absolute_url = settings.url + "/" + link + "/" %}
-{% set cover = Image(gallery.cover) %}
+{% set cover = Image.get(link, gallery.cover) %}
 <meta property="og:title" content="{{ gallery.title }}"/>
-<meta property="og:image" content="{{ absolute_url }}{{ cover.generate_thumbnail("x900") }}"/>
+<meta property="og:image" content="{{ absolute_url }}{{ cover.thumbnail((None, 900)) }}"/>
 <meta property="og:site_name" content="{{ settings.title }}"/>
 {% if gallery.description %}
 <meta property="og:description" content="{{ gallery.description }}"/>

--- a/prosopopee/themes/exposure/templates/opengraph.html
+++ b/prosopopee/themes/exposure/templates/opengraph.html
@@ -1,6 +1,5 @@
 {% set absolute_url = settings.url + "/" + link + "/" %}
 {% set cover = Image(gallery.cover) %}
-{{ cover.copy() }}
 <meta property="og:title" content="{{ gallery.title }}"/>
 <meta property="og:image" content="{{ absolute_url }}{{ cover.generate_thumbnail("x900") }}"/>
 <meta property="og:site_name" content="{{ settings.title }}"/>

--- a/prosopopee/themes/exposure/templates/sections/author.html
+++ b/prosopopee/themes/exposure/templates/sections/author.html
@@ -1,5 +1,4 @@
 {% set image = Image(section.image) %}
-{{ image.copy() }}
 <div class="author-meta">
   <img data-src={{ image.generate_thumbnail("400x400") }} alt="" class="circle lazy">
   <div>

--- a/prosopopee/themes/exposure/templates/sections/author.html
+++ b/prosopopee/themes/exposure/templates/sections/author.html
@@ -1,6 +1,6 @@
-{% set image = Image(section.image) %}
+{% set image = Image.get(link, section.image) %}
 <div class="author-meta">
-  <img data-src={{ image.generate_thumbnail("400x400") }} alt="" class="circle lazy">
+  <img data-src={{ image.thumbnail((400, 400)) }} alt="" class="circle lazy">
   <div>
     <span class=author-info>Story by
       <h4>{{ section.name }}</h4>

--- a/prosopopee/themes/exposure/templates/sections/bordered-picture.html
+++ b/prosopopee/themes/exposure/templates/sections/bordered-picture.html
@@ -20,23 +20,22 @@
     </div>
   </section>
   {% else %}
-  {% set image = Image(section.image) %}
+  {% set image = Image.get(link, section.image) %}
   {% set caption = section.text %}
-  {{ image.copy() }}
   <section class="bordered-picture baguette">
     <div class="caption">
-      <a href="{{ image }}" {% if caption %}data-caption="{{ caption }}"{% endif %}
-         data-at-450="{{ image.generate_thumbnail("x450") }}"
-         data-at-800="{{ image.generate_thumbnail("x800") }}"
-         data-at-1366="{{ image.generate_thumbnail("x1366") }}"
-         data-at-1920="{{ image.generate_thumbnail("x1920") }}"
+      <a href="{{ image.copy() }}" {% if caption %}data-caption="{{ caption }}"{% endif %}
+         data-at-450="{{ image.thumbnail((None, 450)) }}"
+         data-at-800="{{ image.thumbnail((None, 800)) }}"
+         data-at-1366="{{ image.thumbnail((None, 1366)) }}"
+         data-at-1920="{{ image.thumbnail((None, 1920)) }}"
          >
          <picture>
-           <source data-srcset="{{ image.generate_thumbnail("x450") }}" media="(max-width: 450px)"/>
-           <source data-srcset="{{ image.generate_thumbnail("x800") }}" media="(max-width: 800px)"/>
-           <source data-srcset="{{ image.generate_thumbnail("x1366") }}" media="(max-width: 1366px)"/>
-           <source data-srcset="{{ image.generate_thumbnail("x1920") }}" media="(max-width: 1920px)"/>
-           <img class="lazy" src="{% if caption %}./../static/img/11-14.svg{% endif %}" data-src="{{ image.generate_thumbnail("x1920") }}" alt=""/>
+           <source data-srcset="{{ image.thumbnail((None, 450)) }}" media="(max-width: 450px)"/>
+           <source data-srcset="{{ image.thumbnail((None, 800)) }}" media="(max-width: 800px)"/>
+           <source data-srcset="{{ image.thumbnail((None, 1366)) }}" media="(max-width: 1366px)"/>
+           <source data-srcset="{{ image.thumbnail((None, 1920)) }}" media="(max-width: 1920px)"/>
+           <img class="lazy" src="{% if caption %}./../static/img/11-14.svg{% endif %}" data-src="{{ image.thumbnail((None, 1920)) }}" alt=""/>
          </picture>
         {% if caption %}
         <div class="caption__overlay">

--- a/prosopopee/themes/exposure/templates/sections/full-picture.html
+++ b/prosopopee/themes/exposure/templates/sections/full-picture.html
@@ -25,9 +25,8 @@
   </div>
 </section>
 {% else %}
-{% set image = Image(section.image) %}
-{{ image.copy() }}
-<section class="lazy full-picture" data-bg="url({{ image.generate_thumbnail("x2000") }})" style="background-position: {% if section.background_position %} {{ section.background_position }} {% else %} 50% 50%{% endif %}; background-repeat: no-repeat; background-attachment: {% if section.fixed %} fixed {% else %} scroll {% endif %};background-size: cover; height: 100%;">
+{% set image = Image.get(link, section.image) %}
+<section class="lazy full-picture" data-bg="url({{ image.thumbnail((None, 2000)) }})" style="background-position: {% if section.background_position %} {{ section.background_position }} {% else %} 50% 50%{% endif %}; background-repeat: no-repeat; background-attachment: {% if section.fixed %} fixed {% else %} scroll {% endif %};background-size: cover; height: 100%;">
   {% if section.text %}
   <div class="picture-text">
     <div class="picture-text-column animated animatedFadeInUp fadeInUp">

--- a/prosopopee/themes/exposure/templates/sections/panorama.html
+++ b/prosopopee/themes/exposure/templates/sections/panorama.html
@@ -1,4 +1,4 @@
-{% set image = Image(section.image) %}
+{% set image = Image.get(link, section.image) %}
 <section class="panorama">
-  <img src="{{ image.generate_thumbnail("x800") }}">
+  <img src="{{ image.thumbnail((None, 800)) }}">
 </section>

--- a/prosopopee/themes/exposure/templates/sections/panorama.html
+++ b/prosopopee/themes/exposure/templates/sections/panorama.html
@@ -1,5 +1,4 @@
 {% set image = Image(section.image) %}
-{{ image.copy() }}
 <section class="panorama">
   <img src="{{ image.generate_thumbnail("x800") }}">
 </section>

--- a/prosopopee/themes/exposure/templates/sections/paragraph.html
+++ b/prosopopee/themes/exposure/templates/sections/paragraph.html
@@ -9,7 +9,7 @@
     {% endif %}
     <p>
     {% if section.image %}
-    {% set image = Image(section.image) %}
+    {% set image = Image.get(link, section.image) %}
     {% if section.image.float %}
     {% set float = section.image.float %}
     {% else %}
@@ -20,15 +20,14 @@
     {% else %}
     {% set image_resize = '250px' %}
     {% endif %}
-    {{ image.copy() }}
     <span class="{{ float }} baguette">
-      <a href="{{ image }}" {% if caption %}data-caption="{{ caption }}"{% endif %}
-         data-at-450="{{ image.generate_thumbnail("x450") }}"
-         data-at-800="{{ image.generate_thumbnail("x800") }}"
-         data-at-1366="{{ image.generate_thumbnail("x1366") }}"
-         data-at-1920="{{ image.generate_thumbnail("x1920") }}"
+      <a href="{{ image.copy() }}" {% if caption %}data-caption="{{ caption }}"{% endif %}
+         data-at-450="{{ image.thumbnail((None, 450)) }}"
+         data-at-800="{{ image.thumbnail((None, 800)) }}"
+         data-at-1366="{{ image.thumbnail((None, 1366)) }}"
+         data-at-1920="{{ image.thumbnail((None, 1920)) }}"
          >
-         <img class="lazy" style="width: {{ image_resize }};" src="./../static/img/11-14.svg" data-src="{{ image.generate_thumbnail("x600") }}" alt=""/>
+         <img class="lazy" style="width: {{ image_resize }};" src="./../static/img/11-14.svg" data-src="{{ image.thumbnail((None, 600)) }}" alt=""/>
       </a>
     </span>
     {% endif %}

--- a/prosopopee/themes/exposure/templates/sections/pictures-group.html
+++ b/prosopopee/themes/exposure/templates/sections/pictures-group.html
@@ -12,8 +12,7 @@
       {{ video.copy() }}
       {% set ratio = video.ratio %}
       {% else %}
-      {% set image = Image(image) %}
-      {{ image.copy() }}
+      {% set image = Image.get(link, image) %}
       {% set ratio = image.ratio %}
       {% endif %}
       <div class="picture caption" style="flex-grow: {{ ratio }}">
@@ -32,16 +31,16 @@
         </div>
         {% endif %}
         {% else %}
-        <a href="{{ image }}" {% if caption %}data-caption="{{ caption }}"{% endif %}
-           data-at-450="{{ image.generate_thumbnail("x450") }}"
-           data-at-800="{{ image.generate_thumbnail("x800") }}"
-           data-at-1366="{{ image.generate_thumbnail("x1366") }}"
-           data-at-1920="{{ image.generate_thumbnail("x1920") }}"
+        <a href="{{ image.copy() }}" {% if caption %}data-caption="{{ caption }}"{% endif %}
+           data-at-450="{{ image.thumbnail((None, 450)) }}"
+           data-at-800="{{ image.thumbnail((None, 800)) }}"
+           data-at-1366="{{ image.thumbnail((None, 1366)) }}"
+           data-at-1920="{{ image.thumbnail((None, 1920)) }}"
            >
 	{% if loop.length == 1 %}
-           <img class="lazy" src="{% if caption %}./../static/img/11-14.svg{% endif %}" data-src="{{ image.generate_thumbnail("x1366") }}" alt="">
+           <img class="lazy" src="{% if caption %}./../static/img/11-14.svg{% endif %}" data-src="{{ image.thumbnail((None, 1366)) }}" alt="">
 	{% else %}
-           <img class="lazy" src="{% if caption %}./../static/img/11-14.svg{% endif %}" data-src="{{ image.generate_thumbnail("x600") }}" alt="">
+           <img class="lazy" src="{% if caption %}./../static/img/11-14.svg{% endif %}" data-src="{{ image.thumbnail((None, 600)) }}" alt="">
 	{% endif %}
            {% if caption %}
            <div class="caption__overlay">

--- a/prosopopee/themes/light/templates/index.html
+++ b/prosopopee/themes/light/templates/index.html
@@ -38,7 +38,7 @@
       {% set video = Video(gallery.cover) %}
       {{ video.copy() }}
       {% else %}
-      {% set cover = Image(gallery.cover) %}
+      {% set cover = Image.get(gallery.link, gallery.cover) %}
       {% endif %}
       {% if video %}
       <div class="gallery-cover">
@@ -49,7 +49,7 @@
       </div>
       {% set video = "" %}
       {% else %}
-      <div class="gallery-cover" style="background-image: url('{{ cover.generate_thumbnail("x900") }}');"></div>
+      <div class="gallery-cover" style="background-image: url('{{ gallery.link }}/{{ cover.thumbnail((None, 900)) }}');"></div>
       {% endif %}
     </div><!-- comment tricks against space between inline-block
     -->{% endfor %}

--- a/prosopopee/themes/light/templates/index.html
+++ b/prosopopee/themes/light/templates/index.html
@@ -39,7 +39,6 @@
       {{ video.copy() }}
       {% else %}
       {% set cover = Image(gallery.cover) %}
-      {{ cover.copy() }}
       {% endif %}
       {% if video %}
       <div class="gallery-cover">

--- a/prosopopee/themes/light/templates/opengraph.html
+++ b/prosopopee/themes/light/templates/opengraph.html
@@ -7,8 +7,8 @@
 {% endif %}
 <meta property="og:title" content="{{ gallery.title }}"/>
 {% if gallery.cover %}
-{% set cover = Image(gallery.cover) %}
-<meta property="og:image" content="{{ absolute_url }}{{ cover.generate_thumbnail("x900") }}"/>
+{% set cover = Image.get(link + "/" + pathstatic, gallery.cover) %}
+<meta property="og:image" content="{{ absolute_url }}{{ cover.thumbnail((None, 900)) }}"/>
 {% endif %}
 <meta property="og:site_name" content="{{ settings.title }}"/>
 {% if gallery.description %}

--- a/prosopopee/themes/light/templates/opengraph.html
+++ b/prosopopee/themes/light/templates/opengraph.html
@@ -8,7 +8,6 @@
 <meta property="og:title" content="{{ gallery.title }}"/>
 {% if gallery.cover %}
 {% set cover = Image(gallery.cover) %}
-{{ cover.copy() }}
 <meta property="og:image" content="{{ absolute_url }}{{ cover.generate_thumbnail("x900") }}"/>
 {% endif %}
 <meta property="og:site_name" content="{{ settings.title }}"/>

--- a/prosopopee/themes/light/templates/sections/author.html
+++ b/prosopopee/themes/light/templates/sections/author.html
@@ -3,9 +3,9 @@
 {% else %}
 {% set pathstatic = "." %}
 {% endif %}
-{% set image = Image(section.image) %}
+{% set image = Image.get(link + "/" + pathstatic, section.image) %}
 <div class="author-meta">
-  <img src="{{ pathstatic }}/{{ image.generate_thumbnail("200x200") }}" alt="" class="circle">
+  <img src="{{ pathstatic }}/{{ image.thumbnail((200, 200)) }}" alt="" class="circle">
     <div>
         <span class=author-info>Story by
         <h4>{{ section.name }}</h4>

--- a/prosopopee/themes/light/templates/sections/author.html
+++ b/prosopopee/themes/light/templates/sections/author.html
@@ -4,7 +4,6 @@
 {% set pathstatic = "." %}
 {% endif %}
 {% set image = Image(section.image) %}
-{{ image.copy() }}
 <div class="author-meta">
   <img src="{{ pathstatic }}/{{ image.generate_thumbnail("200x200") }}" alt="" class="circle">
     <div>

--- a/prosopopee/themes/light/templates/sections/bordered-picture.html
+++ b/prosopopee/themes/light/templates/sections/bordered-picture.html
@@ -9,7 +9,6 @@
 {{ video.copy() }}
 {% else %}
 {% set image = Image(section.image) %}
-{{ image.copy() }}
 {% endif %}
 {% set caption = section.text %}
 {% if video %}

--- a/prosopopee/themes/light/templates/sections/bordered-picture.html
+++ b/prosopopee/themes/light/templates/sections/bordered-picture.html
@@ -8,7 +8,7 @@
 {% set format = settings.ffmpeg.extension %}
 {{ video.copy() }}
 {% else %}
-{% set image = Image(section.image) %}
+{% set image = Image.get(link + "/" + pathstatic, section.image) %}
 {% endif %}
 {% set caption = section.text %}
 {% if video %}
@@ -19,7 +19,7 @@
 </section>
 {% else %}
 <section class="bordered-picture">
-  <img src="{{ pathstatic }}/{{ image.generate_thumbnail("x800") }}" alt="{% if caption %}{{ caption }}{% endif %}">
+  <img src="{{ pathstatic }}/{{ image.thumbnail((None, 800)) }}" alt="{% if caption %}{{ caption }}{% endif %}">
 </section>
 {% endif %}
 

--- a/prosopopee/themes/light/templates/sections/full-picture.html
+++ b/prosopopee/themes/light/templates/sections/full-picture.html
@@ -9,7 +9,6 @@
 {{ video.copy() }}
 {% else %}
 {% set image = Image(section.image) %}
-{{ image.copy() }}
 {% endif %}
 <div class="full-picture">
     <div class="image">

--- a/prosopopee/themes/light/templates/sections/full-picture.html
+++ b/prosopopee/themes/light/templates/sections/full-picture.html
@@ -8,7 +8,7 @@
 {% set format = settings.ffmpeg.extension %}
 {{ video.copy() }}
 {% else %}
-{% set image = Image(section.image) %}
+{% set image = Image.get(link + "/" + pathstatic, section.image) %}
 {% endif %}
 <div class="full-picture">
     <div class="image">
@@ -17,7 +17,7 @@
           <source src="{{ pathstatic }}/{{ video }}.{{ format }}" type="video/{{ format}}">
         </video>
         {% else %}
-        <img  src="{{ pathstatic }}/{{ image.generate_thumbnail("x800") }}">
+        <img  src="{{ pathstatic }}/{{ image.thumbnail((None, 800)) }}">
         {% endif %}
     </div>
     {% if section.text %}

--- a/prosopopee/themes/light/templates/sections/panorama.html
+++ b/prosopopee/themes/light/templates/sections/panorama.html
@@ -3,7 +3,7 @@
 {% else %}
 {% set pathstatic = "." %}
 {% endif %}
-{% set image = Image(section.image) %}
+{% set image = Image.get(link + "/" + pathstatic, section.image) %}
 <section class="panorama">
-  <img src="{{ pathstatic }}/{{ image.generate_thumbnail("x800") }}">
+  <img src="{{ pathstatic }}/{{ image.thumbnail((None, 800)) }}">
 </section>

--- a/prosopopee/themes/light/templates/sections/panorama.html
+++ b/prosopopee/themes/light/templates/sections/panorama.html
@@ -4,7 +4,6 @@
 {% set pathstatic = "." %}
 {% endif %}
 {% set image = Image(section.image) %}
-{{ image.copy() }}
 <section class="panorama">
   <img src="{{ pathstatic }}/{{ image.generate_thumbnail("x800") }}">
 </section>

--- a/prosopopee/themes/light/templates/sections/paragraph.html
+++ b/prosopopee/themes/light/templates/sections/paragraph.html
@@ -15,7 +15,6 @@
   {% else %}
   {% set float = 'left' %}
   {% endif %}
-  {{ image.copy() }}
   <span class="{{ float }}">
     <img src="{{ pathstatic }}/{{ image.generate_thumbnail("x150") }}" alt=""/>
   </span>

--- a/prosopopee/themes/light/templates/sections/paragraph.html
+++ b/prosopopee/themes/light/templates/sections/paragraph.html
@@ -9,14 +9,14 @@
   {% endif %}
   <p>
   {% if section.image %}
-  {% set image = Image(section.image) %}
+  {% set image = Image.get(link + "/" + pathstatic, section.image) %}
   {% if section.image.float %}
   {% set float = section.image.float %}
   {% else %}
   {% set float = 'left' %}
   {% endif %}
   <span class="{{ float }}">
-    <img src="{{ pathstatic }}/{{ image.generate_thumbnail("x150") }}" alt=""/>
+    <img src="{{ pathstatic }}/{{ image.thumbnail((None, 150)) }}" alt=""/>
   </span>
   {% endif %}
   {{ section.text }}

--- a/prosopopee/themes/light/templates/sections/pictures-group.html
+++ b/prosopopee/themes/light/templates/sections/pictures-group.html
@@ -11,7 +11,7 @@
     {% set format = settings.ffmpeg.extension %}
     {{ video.copy() }}
     {% else %}
-    {% set image = Image(image) %}
+    {% set image = Image.get(link + "/" + pathstatic, image) %}
     {% endif %}
     {% set caption = image.text %}
     <div class="image">
@@ -21,7 +21,7 @@
         </video>
         {% set video = "" %}
         {% else %}
-        <img src="{{ pathstatic }}/{{ image.generate_thumbnail("x800") }}" alt="{% if caption %}{{ caption }}{% endif %}">
+        <img src="{{ pathstatic }}/{{ image.thumbnail((None, 800)) }}" alt="{% if caption %}{{ caption }}{% endif %}">
         {% endif %}
     </div>
     {% endfor %}

--- a/prosopopee/themes/light/templates/sections/pictures-group.html
+++ b/prosopopee/themes/light/templates/sections/pictures-group.html
@@ -12,7 +12,6 @@
     {{ video.copy() }}
     {% else %}
     {% set image = Image(image) %}
-    {{ image.copy() }}
     {% endif %}
     {% set caption = image.text %}
     <div class="image">

--- a/prosopopee/themes/material/templates/index.html
+++ b/prosopopee/themes/material/templates/index.html
@@ -34,8 +34,8 @@
         <img class="fillWidth" alt="" src="{{ video.generate_thumbnail("900") }}">
       </div>
       {% else %}
-      {% set cover = Image(gallery.cover) %}
-      <div class="gallery-cover" style="background-image: url('{{ cover.generate_thumbnail("x900") }}'), url('{{ cover.generate_thumbnail("x150") }}');"></div>
+      {% set cover = Image.get(gallery.link, gallery.cover) %}
+      <div class="gallery-cover" style="background-image: url('{{ cover.thumbnail((None, 900)) }}'), url('{{ cover.thumbnail((None, 150)) }}');"></div>
       {% endif %}
     </div><!-- comment tricks against space between inline-block
     -->{% endfor %}

--- a/prosopopee/themes/material/templates/index.html
+++ b/prosopopee/themes/material/templates/index.html
@@ -35,7 +35,6 @@
       </div>
       {% else %}
       {% set cover = Image(gallery.cover) %}
-      {{ cover.copy() }}
       <div class="gallery-cover" style="background-image: url('{{ cover.generate_thumbnail("x900") }}'), url('{{ cover.generate_thumbnail("x150") }}');"></div>
       {% endif %}
     </div><!-- comment tricks against space between inline-block

--- a/prosopopee/themes/material/templates/opengraph.html
+++ b/prosopopee/themes/material/templates/opengraph.html
@@ -1,7 +1,7 @@
 {% set absolute_url = settings.url + "/" + link + "/" %}
-{% set cover = Image(gallery.cover) %}
+{% set cover = Image.get(gallery.link, gallery.cover) %}
 <meta property="og:title" content="{{ gallery.title }}"/>
-<meta property="og:image" content="{{ absolute_url }}{{ cover.generate_thumbnail("x900") }}"/>
+<meta property="og:image" content="{{ absolute_url }}{{ cover.thumbnail((None, 900)) }}"/>
 <meta property="og:site_name" content="{{ settings.title }}"/>
 {% if gallery.description %}
 <meta property="og:description" content="{{ gallery.description }}"/>

--- a/prosopopee/themes/material/templates/opengraph.html
+++ b/prosopopee/themes/material/templates/opengraph.html
@@ -1,6 +1,5 @@
 {% set absolute_url = settings.url + "/" + link + "/" %}
 {% set cover = Image(gallery.cover) %}
-{{ cover.copy() }}
 <meta property="og:title" content="{{ gallery.title }}"/>
 <meta property="og:image" content="{{ absolute_url }}{{ cover.generate_thumbnail("x900") }}"/>
 <meta property="og:site_name" content="{{ settings.title }}"/>

--- a/prosopopee/themes/material/templates/sections/author.html
+++ b/prosopopee/themes/material/templates/sections/author.html
@@ -1,5 +1,4 @@
 {% set image = Image(section.image) %}
-{{ image.copy() }}
 <div class="container author">
     <div class="section">
         <div class="row">

--- a/prosopopee/themes/material/templates/sections/author.html
+++ b/prosopopee/themes/material/templates/sections/author.html
@@ -1,4 +1,4 @@
-{% set image = Image(section.image) %}
+{% set image = Image.get(link, section.image) %}
 <div class="container author">
     <div class="section">
         <div class="row">
@@ -7,7 +7,7 @@
                 <div class="section">
                     <div class="row valign-wrapper">
                         <div class="col s2">
-                            <img src={{ image.generate_thumbnail("200x200") }} alt="" class="circle responsive-img"> 
+                            <img src={{ image.thumbnail((200, 200)) }} alt="" class="circle responsive-img">
                         </div>
                         <div class="col s10">
                             <div class="section">

--- a/prosopopee/themes/material/templates/sections/bordered-picture.html
+++ b/prosopopee/themes/material/templates/sections/bordered-picture.html
@@ -2,9 +2,8 @@
 {% set video = Video(section.image) %}
 {% set format = settings.ffmpeg.extension %}
 {% else %}
-{% set image = Image(section.image) %}
+{% set image = Image.get(link, section.image) %}
 {% set caption = section.text %}
-{{ image.copy() }}
 {% endif %}
 {% if section.background %}
 <div style="padding: 1px 0px;background: {{ section.background }};">
@@ -16,13 +15,13 @@
       <source src="{{ video }}.{{ format }}" type="video/{{ format }}">
     </video>
     {% else %}
-    <a href="{{ image }}" {% if caption %}data-caption="{{ caption }}"{% endif %}
-       data-at-450="{{ image.generate_thumbnail("x450") }}"
-       data-at-800="{{ image.generate_thumbnail("x800") }}"
-       data-at-1366="{{ image.generate_thumbnail("x1366") }}"
-       data-at-1920="{{ image.generate_thumbnail("x1920") }}"
+    <a href="{{ image.copy() }}" {% if caption %}data-caption="{{ caption }}"{% endif %}
+       data-at-450="{{ image.thumbnail((None, 450)) }}"
+       data-at-800="{{ image.thumbnail((None, 800)) }}"
+       data-at-1366="{{ image.thumbnail((None, 1366)) }}"
+       data-at-1920="{{ image.thumbnail((None, 1920)) }}"
        >
-       <img class="responsive-img lazy z-depth-2" data-original="{{ image.generate_thumbnail("x2000") }}" alt="">
+       <img class="responsive-img lazy z-depth-2" data-original="{{ image.thumbnail((None, 2000)) }}" alt="">
        {% if caption %}
        <div class="caption__overlay card-panel center">
          <h5 class="black-white">{{ caption }}</h5>

--- a/prosopopee/themes/material/templates/sections/full-picture.html
+++ b/prosopopee/themes/material/templates/sections/full-picture.html
@@ -8,9 +8,8 @@
       <source src="{{ video }}.{{ format }}" type="video/{{ format }}">
     </video>
     {% else %}
-    {% set image = Image(section.image) %}
-    {{ image.copy() }}
-    <img class="responsive-img" src="{{ image }}">
+    {% set image = Image.get(link, section.image) %}
+    <img class="responsive-img" src="{{ image.copy() }}">
     {% endif %}
   </div>
 

--- a/prosopopee/themes/material/templates/sections/panorama.html
+++ b/prosopopee/themes/material/templates/sections/panorama.html
@@ -1,5 +1,4 @@
-{% set image = Image(section.image) %}
-{{ image.copy() }}
+{% set image = Image.get(link, section.image) %}
 <div class="panorama">
-    <img src="{{ image }}">
+    <img src="{{ image.copy() }}">
 </div>

--- a/prosopopee/themes/material/templates/sections/paragraph.html
+++ b/prosopopee/themes/material/templates/sections/paragraph.html
@@ -12,7 +12,7 @@
 
       <p class="flow-text">
       {% if section.image %}
-      {% set image = Image(section.image) %}
+      {% set image = Image.get(link, section.image) %}
       {% if section.image.float %}
       {% set float = section.image.float %}
       {% else %}
@@ -23,15 +23,14 @@
       {% else %}
       {% set image_resize = '250px' %}
       {% endif %}
-			{{ image.copy() }}
 			<span class="{{ float }} baguette">
-				<a href="{{ image }}" {% if caption %}data-caption="{{ caption }}"{% endif %}
-			 		data-at-450="{{ image.generate_thumbnail("x450") }}"
-					data-at-800="{{ image.generate_thumbnail("x800") }}"
-					data-at-1366="{{ image.generate_thumbnail("x1366") }}"
- 					data-at-1920="{{ image.generate_thumbnail("x1920") }}"
- 				>
-					<img class="lazy" style="width: {{ image_resize }};" src="" data-original="{{ image.generate_thumbnail("x450") }}" alt=""/>
+				<a href="{{ image.copy() }}" {% if caption %}data-caption="{{ caption }}"{% endif %}
+					data-at-450="{{ image.thumbnail((None, 450)) }}"
+					data-at-800="{{ image.thumbnail((None, 800)) }}"
+					data-at-1366="{{ image.thumbnail((None, 1366)) }}"
+					data-at-1920="{{ image.thumbnail((None, 1920)) }}"
+				>
+					<img class="lazy" style="width: {{ image_resize }};" src="" data-original="{{ image.thumbnail((None, 450)) }}" alt=""/>
 				</a>
 			</span>
 			{% endif %}

--- a/prosopopee/themes/material/templates/sections/pictures-group.html
+++ b/prosopopee/themes/material/templates/sections/pictures-group.html
@@ -12,8 +12,7 @@
       {{ video.copy() }}
       {% set ratio = video.ratio %}
       {% else %}
-      {% set image = Image(image) %}
-      {{ image.copy() }}
+      {% set image = Image.get(link, image) %}
       {% set ratio = image.ratio %}
       {% endif %}
       <div class="picture caption" style="flex-grow: {{ ratio }}">
@@ -28,13 +27,13 @@
         </div>
         {% endif %}
         {% else %}
-        <a href="{{ image }}" {% if caption %}data-caption="{{ caption }}"{% endif %}
-           data-at-450="{{ image.generate_thumbnail("x450") }}"
-           data-at-800="{{ image.generate_thumbnail("x800") }}"
-           data-at-1366="{{ image.generate_thumbnail("x1366") }}"
-           data-at-1920="{{ image.generate_thumbnail("x1920") }}"
+        <a href="{{ image.copy() }}" {% if caption %}data-caption="{{ caption }}"{% endif %}
+           data-at-450="{{ image.thumbnail((None, 450)) }}"
+           data-at-800="{{ image.thumbnail((None, 800)) }}"
+           data-at-1366="{{ image.thumbnail((None, 1366)) }}"
+           data-at-1920="{{ image.thumbnail((None, 1920)) }}"
            >
-           <img class="lazy responsive-img z-depth-2" src="" data-original="{{ image.generate_thumbnail("x600") }}" alt="">
+           <img class="lazy responsive-img z-depth-2" src="" data-original="{{ image.thumbnail((None, 600)) }}" alt="">
            {% if caption %}
            <div class="caption__overlay">
              <h5 class="caption__overlay__title">{{ caption }}</h5>

--- a/prosopopee/utils.py
+++ b/prosopopee/utils.py
@@ -15,7 +15,10 @@ logger = logging.getLogger("prosopopee." + __name__)
 
 def remove_superficial_options(options):
     cleaned_options = options.copy()
-    del cleaned_options["name"]
+    if "name" in cleaned_options:
+        del cleaned_options["name"]
+    if "exif" in cleaned_options:
+        del cleaned_options["exif"]
     if "text" in cleaned_options:
         del cleaned_options["text"]
     if "type" in cleaned_options:
@@ -24,6 +27,12 @@ def remove_superficial_options(options):
         del cleaned_options["size"]
     if "float" in cleaned_options:
         del cleaned_options["float"]
+    # "resize" only applies to image.copy() in templates, no need to propagate it to the cache since
+    # the actual size of the "copy" thumbnail is part of the filename and will trigger a
+    # regeneration if changed (thus "resize" setting is appropriately watched without regenerating
+    # non-copy thumbnails).
+    if "resize" in cleaned_options:
+        del cleaned_options["resize"]
     return cleaned_options
 
 

--- a/prosopopee/utils.py
+++ b/prosopopee/utils.py
@@ -10,6 +10,9 @@ from path import Path
 import ruamel.yaml as yaml
 
 
+logger = logging.getLogger("prosopopee." + __name__)
+
+
 def remove_superficial_options(options):
     cleaned_options = options.copy()
     del cleaned_options["name"]
@@ -88,32 +91,32 @@ def load_settings(folder):
         msg = "There is something wrong in %s/settings.yaml" % folder
         if isinstance(exc, yaml.error.MarkedYAMLError):
             msg = msg + str(exc.context_mark)
-        logging.error(msg)
+        logger.error(msg)
         sys.exit(1)
     except ValueError:
-        logging.error(
+        logger.error(
             "Incorrect data format, should be YYYY-MM-DD in %s/settings.yaml", folder
         )
         sys.exit(1)
     except Exception as exc:
-        logging.exception(exc)
+        logger.exception(exc)
         sys.exit(1)
 
     if gallery_settings is None:
-        logging.error("The %s/settings.yaml file is empty", folder)
+        logger.error("The %s/settings.yaml file is empty", folder)
         sys.exit(1)
     elif not isinstance(gallery_settings, dict):
-        logging.error("%s/settings.yaml should be a dict", folder)
+        logger.error("%s/settings.yaml should be a dict", folder)
         sys.exit(1)
     elif "title" not in gallery_settings:
-        logging.error("You should specify a title in %s/settings.yaml", folder)
+        logger.error("You should specify a title in %s/settings.yaml", folder)
         sys.exit(1)
 
     if gallery_settings.get("date"):
         try:
             datetime.strptime(str(gallery_settings.get("date")), "%Y-%m-%d")
         except ValueError:
-            logging.error(
+            logger.error(
                 "Incorrect data format, should be YYYY-MM-DD in %s/settings.yaml",
                 folder,
             )

--- a/prosopopee/utils.py
+++ b/prosopopee/utils.py
@@ -10,6 +10,20 @@ from path import Path
 import ruamel.yaml as yaml
 
 
+def remove_superficial_options(options):
+    cleaned_options = options.copy()
+    del cleaned_options["name"]
+    if "text" in cleaned_options:
+        del cleaned_options["text"]
+    if "type" in cleaned_options:
+        del cleaned_options["type"]
+    if "size" in cleaned_options:
+        del cleaned_options["size"]
+    if "float" in cleaned_options:
+        del cleaned_options["float"]
+    return cleaned_options
+
+
 class CustomFormatter(logging.Formatter):
     """Logging Formatter to add colors"""
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ path.py
 ruamel.yaml
 future
 pillow>=6
+imagesize


### PR DESCRIPTION
**A notable change is that the resize option for images only accepts
percentages for now.**

**Another notable change is that the .copy() function actually also
applies the quality setting, unlike the implementation with
graphicsmagick.**

This has been tested against Pillow from 6.0.0 to 8.1.0 and Pillow-SIMD
7.0.0.post3.

Here are the different benchmarks. The setup is the following: ~1400 photos spread among 31 galleries. Building everything from scratch. Graphicsmagick means the current implementation in prosopopee. "Built Pillow 8.1.0" can be reproduced by installing libjpegturbo and then running `pip3 install --no-binary :all: --force-reinstall pillow`. Please follow https://pillow.readthedocs.io/en/stable/installation.html#building-from-source to make sure you have all the packages installed in your distribution prior to trying to compile Pillow.

| Computer | Graphicsmagick | Pillow 8.1.0 | Built Pillow 8.1.0 | Pillow-SIMD 7.0.0.post3 |
|--|--|--|--|--|
| Intel Q6600 (4c/4t @2.4GHz) 4GB RAM (Fedora Desktop 33)| 1:37:13.06 | 26:57.71 | 17:43.66 | N/A |
| Intel Atom N2800 (2c/4t @1.86GHz 2GB RAM (Fedora Server 33)| 5:35:32.57 | 1:44:21.93 | 1:16:32.42 | N/A |
| Intel Celeron G1610T (2c/2t @2.3GHz) 4GB RAM (Fedora Server 33)| 1:42:33.79 | 46:10.00 | 26:10.30 | 17:30.49 |
| Intel Core i7-8700 (6c/12t @3.2GHz) 32GB RAM (Ubuntu Desktop 20.04.2)| 33:01.63 | 6:00.16 | 3:40.09 | 2:16.03 |
| RaspberryPi 4 4GB RAM (Ubuntu Server 20.10)| 3:44:57.00 | 44:43.67 | 33:29.86 | N/A |

Regenerating only one gallery of 71 photos:
| Computer | Graphicsmagick | Pillow 8.1.0 | Built Pillow 8.1.0 | Pillow-SIMD 7.0.0.post3 |
|--|--|--|--|--|
| Intel Q6600 (4c/4t @2.4GHz) 4GB RAM (Fedora Desktop 33)| 3:59.49 | 1:37.47 | 1:13.93 | N/A |
| Intel Atom N2800 (2c/4t @1.86GHz 2GB RAM (Fedora Server 33)| 14:59.40 | 6:09.36 | 5:04.45 | N/A |
| Intel Celeron G1610T (2c/2t @2.3GHz) 4GB RAM (Fedora Server 33)| 4:33.75 | 2:31.85 | 1:45.11 | 1:18.00 |
| Intel Core i7-8700 (6c/12t @3.2GHz) 32GB RAM (Ubuntu Desktop 20.04.2) | 1:31.09 | 21.179 | 12.373 | 8.665 |
| RaspberryPi 4 4GB RAM (Ubuntu Server 20.10)| 10:26.63 | 2:23.45 | 2:22.50 | N/A |

Currently, thumbnail generation is done in a single thread while parsing
the galleries by calling graphicsmagick for every thumbnail to be
generated. This is suboptimal even though graphicsmagick spreads its
payload over all available CPU cores.

After a quick and dirty benchmarking, it was found that multiprocessed
Pillow for generating thumbnails was much more efficient than
graphicsmagick.

This PR adds support for generation of tuhmbnails with multiprocessed
Pillow.

Multiple processes have to be used and not multiple threads because
Python still uses the Global Interpreter Lock (GIL) for threads, meaning
they cannot concurrently be running, which is what one wants for CPU
intensive tasks such as thumbnail generation.

Multiprocess brings its own set of challenges because most data
structures cannot be shared between processes, such as the cache for
example. All data modified by any of the processes should be of a type
handled by multiprocess.Manager data structures.

In order to have the best performances, all thumbnails for an image
should be generated at once, so that the original image is opened only
once. This therefore requires to keep track of images and add thumbnails
to be created to the original image. This can be done via a factory
which is passed to the Jinja templates so that they can request
thumbnails for given images without knowing more than the original path,
name of the original image and the parameters of the thumbnails to
create.

The ImageFactory keeps all of those original images in a dictionary
which consists of a virtual path made from the original image name and a
CRC32 of all the options that applies to its thumbnails. This gives
prosopopee the ability to group thumbnails per options (e.g. if options
are passed in gallery settings.yaml).

The original image (or BaseImage) is returned by the ImageFactory and
the templates can then request .copy() or .thumbnail() for it.

The thumbnails are kept in a dictionary whose keys are the name of the
thumbnail which is made out of the original name plus its size and the
crc32 of the original image and the options that apply to it. This way,
thumbnails are guaranteed to be unique even if requested multiple times
by templates.

The size is now read with imagesize.getsize() only once when ratio
property or .copy() is called on the image so that the performance impact
is minimal.

Since multiprocess.Pool.map splits iterables into pre-defined chunks
which are then assigned to processes, it is needed for best performance
to have processes with more or less the same taskload so that one or
more processes aren't idle when one is working 100%. For that, the
original images whose thumbnails are all cached should be removed from
the list of images to generate thumbnails from before the list is passed
to multiprocess.Pool.map so that each process has more or less the same
taskload.

Thanks,
Quentin