### PR TITLE
Gallery cover videos (play and fill)

### DIFF
--- a/prosopopee/themes/exposure/static/css/style.css
+++ b/prosopopee/themes/exposure/static/css/style.css
@@ -80,6 +80,7 @@ a {
     background-position: center center;
     background-size: cover;
     overflow: hidden;
+    display: flex;
 }
 
 .gallery-title {
@@ -258,20 +259,12 @@ nav ul li > a.item-menu::before {
     font-style: normal;
 }
 
-.gallery-cover video.fillWidth {
-    height: 100%;
-    position: absolute;
-    top: 0px;
-    left: 0px;
-}
-
 .gallery-cover img.fillWidth,
 .gallery-cover video.fillWidth {
-  top: 0;bottom: 0;right: 0;left: 0;margin: auto;
-}
-
-.gallery-cover video.fillWidth {
-  min-width: 50%;
+  margin: auto;
+  min-height: 100%;
+  min-width: 100%;
+  object-fit: cover;
 }
 
 .back-to-home {

--- a/prosopopee/themes/exposure/templates/index.html
+++ b/prosopopee/themes/exposure/templates/index.html
@@ -42,10 +42,11 @@
       </a>
       {% if gallery.cover_type == "video" %}
       {% set video = Video(gallery.cover) %}
+      {% set format = settings.ffmpeg.extension %}
       {{ video.copy() }}
       <div class="gallery-cover">
         <video autoplay loop muted class="fillWidth">
-          <source src="{{ video }}" type="video/webm" data-source="{{ video }}" data-format="vp8" data-extension="webm">
+          <source src="{{ video }}.{{ format }}" type="video/{{ format }}">
         </video>
         <img class="fillWidth" alt="" src="{{ video.generate_thumbnail("900") }}">
       </div>


### PR DESCRIPTION
The gallery image covers fill the parent div whatever their ratio or size is, let's do the same for video covers (this will obviously crop some parts of the video).

Also, now the video covers are played in the gallery index (the code was there but not working, so I guess playing videos in the gallery index was intended).