### PR TITLE
exposure: fix bordered-picture taking more than screen height when image is portrait

### DIFF
--- a/prosopopee/themes/exposure/static/css/style-page.css
+++ b/prosopopee/themes/exposure/static/css/style-page.css
@@ -71,11 +71,16 @@ a {
   letter-spacing: 2px;
 }
 
-.bordered-picture img {
-  height: 77%;
-  width: 77%;
+.bordered-picture {
+  display: flex;
+  justify-content: center;
   margin-left: 11.5%;
   margin-right: 11.5%;
+}
+
+.bordered-picture img {
+  max-height: 100vh;
+  max-width: 100%;
 }
 
 .pictures-line {


### PR DESCRIPTION
The bordered-picture is now limited in width and height to the one of the
display, making it possible to have a portrait picture as
bordered-picture and have it only take 100% of the display and not more.

Fixes #139.