### PR TITLE
Fixed deprecated name path.py in favor of path

### DIFF
--- a/prosopopee/utils.py
+++ b/prosopopee/utils.py
@@ -66,10 +66,11 @@ def rfc822(date):
 
 def load_settings(folder):
     try:
+        set_yaml = yaml.YAML(typ='safe', pure=True)
         with open(
             Path(".").joinpath(folder, "settings.yaml").abspath(), "r"
         ) as settings:
-            gallery_settings = yaml.safe_load(settings.read())
+            gallery_settings = set_yaml.load(settings.read())
     except (yaml.error.MarkedYAMLError, yaml.YAMLError) as exc:
         msg = "There is something wrong in %s/settings.yaml" % folder
         if isinstance(exc, yaml.error.MarkedYAMLError):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Babel
 jinja2
-path.py
+path
 ruamel.yaml
 future
 pillow>=6


### PR DESCRIPTION
The title is self-describing. The current version 2.2 of `path.py` produces the following error:

```
File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1002, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 945, in _find_spec
  File "<frozen importlib._bootstrap_external>", line 1439, in find_spec
  File "<frozen importlib._bootstrap_external>", line 1411, in _get_spec
  File "<frozen zipimport>", line 170, in find_spec
  File "<frozen importlib._bootstrap>", line 431, in spec_from_loader
  File "<frozen importlib._bootstrap_external>", line 741, in spec_from_file_location
  File "<frozen zipimport>", line 229, in get_filename
  File "<frozen zipimport>", line 767, in _get_module_code
  File "<frozen zipimport>", line 696, in _compile_source
  File "/util/lib/python3.10/site-packages/path-2.2-py3.10.egg/path.py", line 886
    def mkdir(self, mode=0777):
                         ^
SyntaxError: leading zeros in decimal integer literals are not permitted; use an 0o prefix for octal integers
```
inherited from Python 2, now it is definitely deprecated. Closes #124 

-----

Also fixes `ruamel.yaml` `safe_load()` function removal. Closes #151 