### PR TITLE
Locked jinja2 version to <3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-<p align="center">
-<img src="logo.png">
-</p>
+# Prosopopee-flex
 
-# Prosopopee
+A fork of [Prosopopee](https://github.com/Psycojoker/prosopopee/) with the intention of improving flexibility in site structure and presentation.
+
+---
 
 Prosopopee. Static site generator for your story.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Prosopopee-flex
+# Prosopopee[flex]
 
 A fork of [Prosopopee](https://github.com/Psycojoker/prosopopee/) with the intention of improving flexibility in site structure and presentation.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prosopopee[flex]
 
-A fork of [Prosopopee](https://github.com/Psycojoker/prosopopee/) with the intention of improving flexibility in site structure and presentation.
+A fork of [Prosopopee](https://github.com/Psycojoker/prosopopee/) with the intention of improving flexibility in site structure and presentation - primarily to allow custom content sections to be added on the root page.
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Babel
-jinja2
+jinja2<3.1
 path
 ruamel.yaml
 future


### PR DESCRIPTION
Workaround for issue #147 by locking `jjinja2` below version 3.1